### PR TITLE
Sett lik memory request og limit

### DIFF
--- a/nais/dev-gcp/nais.yaml
+++ b/nais/dev-gcp/nais.yaml
@@ -33,7 +33,7 @@ spec:
       memory: 768Mi
     requests:
       cpu: "20m"
-      memory: 128Mi
+      memory: 768Mi
   env:
     - name: URL_EF_MINSIDE
       value: "https://familie.ekstern.dev.nav.no/familie/alene-med-barn/minside"

--- a/nais/prod-gcp/nais.yaml
+++ b/nais/prod-gcp/nais.yaml
@@ -33,7 +33,7 @@ spec:
       memory: 768Mi
     requests:
       cpu: "20m"
-      memory: 128Mi
+      memory: 768Mi
   env:
     - name: URL_EF_MINSIDE
       value: "https://www.nav.no/familie/alene-med-barn/minside"


### PR DESCRIPTION
## Hva
Setter `resources.requests.memory` lik `resources.limits.memory` i nais.yaml-filene.

## Hvorfor
Anbefalt praksis for Kubernetes-ressurser er å ha requests og limits like for minne, se
https://www.flexera.com/blog/finops/kubernetes-limits-vs-requests-key-differences-and-how-they-work/#s5

Ingen CPU-limit er satt i denne appen, så det er ikke gjort endringer der.
