### PR TITLE
Juster ressurser etter Nais-anbefaling

### DIFF
--- a/nais/dev-gcp/nais.yaml
+++ b/nais/dev-gcp/nais.yaml
@@ -30,10 +30,10 @@ spec:
           namespace: min-side
   resources:
     limits:
-      memory: 768Mi
+      memory: 192Mi
     requests:
-      cpu: "20m"
-      memory: 768Mi
+      cpu: "50m"
+      memory: 192Mi
   env:
     - name: URL_EF_MINSIDE
       value: "https://familie.ekstern.dev.nav.no/familie/alene-med-barn/minside"

--- a/nais/prod-gcp/nais.yaml
+++ b/nais/prod-gcp/nais.yaml
@@ -30,10 +30,10 @@ spec:
           namespace: min-side
   resources:
     limits:
-      memory: 768Mi
+      memory: 256Mi
     requests:
-      cpu: "20m"
-      memory: 768Mi
+      cpu: "75m"
+      memory: 256Mi
   env:
     - name: URL_EF_MINSIDE
       value: "https://www.nav.no/familie/alene-med-barn/minside"


### PR DESCRIPTION
## Hva
Justerer CPU/memory requests og limits etter Nais console sine anbefalinger (basert på faktisk bruk). Forrige runde satte vi `memory request = limit`, men på de gamle høye verdiene, noe som ga over-reservering flagget som «dyrere ressurser enn forventet».

## Hvordan
- **Memory:** `request = limit` beholdt (Guaranteed QoS), satt til Nais sitt anbefalte limit avrundet til ren verdi.
- **CPU request** justert mot anbefaling. Ingen CPU-limit.