### PR TITLE
Legger til scope for npm registries

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,7 @@ registries:
     type: npm-registry
     url: https://npm.pkg.github.com
     token: ${{ secrets.READER_TOKEN }}
+    scope: "@navikt"
 
 updates:
   - package-ecosystem: github-actions


### PR DESCRIPTION
Nylig endring som gjør at dependabot trenger scope for å generere .npmrc for å kjøre riktig ser det ut som https://github.blog/changelog/2026-06-30-dependabot-no-longer-infers-npmrc/